### PR TITLE
fix oauth: @RequestBody의 Swagger 관련 어노테이션 제거하여 오류 해결

### DIFF
--- a/src/main/java/com/_ithon/speeksee/global/auth/controller/OAuthController.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/controller/OAuthController.java
@@ -3,6 +3,7 @@ package com._ithon.speeksee.global.auth.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,9 +15,6 @@ import com._ithon.speeksee.global.infra.exception.code.ErrorCode;
 import com._ithon.speeksee.global.infra.exception.response.ApiRes;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,12 +28,7 @@ public class OAuthController {
 
 	private final OAuth2LoginService oAuth2LoginService;
 
-	@Operation(summary = "Google 로그인", description = "Google OAuth2 인가 코드를 이용하여 로그인하고 JWT 토큰을 반환합니다",
-		requestBody = @RequestBody(
-			description = "Google 인가 코드",
-			required = true,
-			content = @Content(schema = @Schema(implementation = GoogleOAuthRequestDto.class))
-		)
+	@Operation(summary = "Google 로그인", description = "Google OAuth2 인가 코드를 이용하여 로그인하고 JWT 토큰을 반환합니다"
 	)
 	@ApiResponses(value = {
 		@ApiResponse(


### PR DESCRIPTION
## 개요
oauth 로그인이 안되는 문제
@RequestBody 어노테이션이 스웨거 문서용 어노테이션이어서 json 바디 값을 받아오지 못하는 거였습니다

resolves #(Isuue Number)

## PR 유형
- [x] 버그 수정