### PR TITLE
Refactor 코드 개선

### DIFF
--- a/src/main/java/com/_ithon/speeksee/domain/member/entity/Member.java
+++ b/src/main/java/com/_ithon/speeksee/domain/member/entity/Member.java
@@ -22,12 +22,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@Builder
 @Entity
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 public class Member extends BaseTimeEntity {
 
 	@Id
@@ -50,8 +50,10 @@ public class Member extends BaseTimeEntity {
 	@Column
 	private String providerId; // 각 소셜 서비스에서 제공하는 고유 ID
 
-	private String currentLevel ="초급";
+	@Builder.Default
+	private String currentLevel = "초급";
 
+	@Builder.Default
 	private Integer totalExp = 0;
 
 	private LocalDate lastLogin;
@@ -59,6 +61,7 @@ public class Member extends BaseTimeEntity {
 	private Integer consecutiveDays;
 
 	@OneToMany(mappedBy = "author", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
 	private List<Script> scripts = new ArrayList<>();
 
 	public void addScript(Script script) {
@@ -70,5 +73,4 @@ public class Member extends BaseTimeEntity {
 		scripts.remove(script);
 		script.setAuthor(null);
 	}
-
 }

--- a/src/main/java/com/_ithon/speeksee/domain/voicefeedback/streaming/infra/client/GoogleStreamingSttClient.java
+++ b/src/main/java/com/_ithon/speeksee/domain/voicefeedback/streaming/infra/client/GoogleStreamingSttClient.java
@@ -153,27 +153,6 @@ public class GoogleStreamingSttClient implements StreamingSttClient {
 		}
 	}
 
-	/**
-	 * WebSocket 세션에서 쿼리 파라미터를 추출합니다.
-	 * <p>
-	 * 예: "memberId=1&scriptId=3"에서 memberId 또는 scriptId 값을 추출합니다.
-	 *
-	 * @param session WebSocket 세션
-	 * @param key     추출할 파라미터 키 (예: "memberId" 또는 "scriptId")
-	 * @return 해당 키의 값, 없으면 null
-	 */
-	private String getQueryParam(WebSocketSession session, String key) {
-		String query = session.getUri().getQuery(); // 예: "memberId=1&scriptId=3"
-		if (query == null) return null;
-
-		for (String param : query.split("&")) {
-			String[] pair = param.split("=");
-			if (pair.length == 2 && pair[0].equals(key)) {
-				return pair[1];
-			}
-		}
-		return null;
-	}
 
 	/**
 	 * WebSocket 세션에서 오디오 데이터를 수신할 때 호출됩니다.

--- a/src/main/java/com/_ithon/speeksee/domain/voicefeedback/streaming/repository/ScriptPracticeRepository.java
+++ b/src/main/java/com/_ithon/speeksee/domain/voicefeedback/streaming/repository/ScriptPracticeRepository.java
@@ -4,8 +4,10 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com._ithon.speeksee.domain.member.entity.Member;
 import com._ithon.speeksee.domain.voicefeedback.streaming.entity.ScriptPractice;
 
 public interface ScriptPracticeRepository extends JpaRepository<ScriptPractice, Long> {
-	List<ScriptPractice> findAllByMemberId(Long memberId);
+	List<ScriptPractice> findAllByMember(Member member);
+
 }

--- a/src/main/java/com/_ithon/speeksee/global/infra/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/_ithon/speeksee/global/infra/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com._ithon.speeksee.global.infra.exception.code.ErrorCode;
 import com._ithon.speeksee.global.infra.exception.entityException.MemberNotFoundException;
+import com._ithon.speeksee.global.infra.exception.entityException.PracticeNotFoundException;
 import com._ithon.speeksee.global.infra.exception.entityException.ScriptNotFoundException;
 import com._ithon.speeksee.global.infra.exception.response.ApiRes;
 
@@ -64,6 +65,12 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(MemberNotFoundException.class)
 	public ResponseEntity<ApiRes<Void>> handleMemberNotFound(MemberNotFoundException e) {
+		return ResponseEntity.status(e.getStatus())
+			.body(ApiRes.failure(e.getStatus(), e.getMessage(), e.getErrorCode()));
+	}
+
+	@ExceptionHandler(PracticeNotFoundException.class)
+	public ResponseEntity<ApiRes<Void>> handlePracticeNotFound(PracticeNotFoundException e) {
 		return ResponseEntity.status(e.getStatus())
 			.body(ApiRes.failure(e.getStatus(), e.getMessage(), e.getErrorCode()));
 	}

--- a/src/main/java/com/_ithon/speeksee/global/infra/exception/code/ErrorCode.java
+++ b/src/main/java/com/_ithon/speeksee/global/infra/exception/code/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
 	SCRIPT_GENERATION_FAILED(2002, "대본 생성에 실패했습니다."),
 	SCRIPT_NOT_FOUND(2003, "해당 대본을 찾을 수 없습니다."),
 	VOICE_FEEDBACK_INVALID(2004, "음성 피드백 요청이 유효하지 않습니다.")
+	,PraCTICE_NOT_FOUND(2005, "해당 연습을 찾을 수 없습니다.")
 	;
 
 	private final int code;

--- a/src/main/java/com/_ithon/speeksee/global/infra/exception/entityException/PracticeNotFoundException.java
+++ b/src/main/java/com/_ithon/speeksee/global/infra/exception/entityException/PracticeNotFoundException.java
@@ -1,0 +1,12 @@
+package com._ithon.speeksee.global.infra.exception.entityException;
+
+import org.springframework.http.HttpStatus;
+
+import com._ithon.speeksee.global.infra.exception.SpeekseeException;
+import com._ithon.speeksee.global.infra.exception.code.ErrorCode;
+
+public class PracticeNotFoundException extends SpeekseeException{
+	public PracticeNotFoundException() {
+		super(HttpStatus.NOT_FOUND, ErrorCode.PraCTICE_NOT_FOUND);
+	}
+}


### PR DESCRIPTION
## 개요

close: #25 

## ✨ PR 내용 요약

1. `PracticeController` 단건 연습 조회 API 개선  
   - 기존 `@PathVariable`에서 → `@RequestParam`으로 파라미터 방식 변경  
   - 클라이언트가 scriptId를 쿼리로 명시적으로 전달하도록 개선

2. `Member` 엔티티 개선  
   - builder 패턴 사용 시 `currentLevel`, `totalExp`, `scripts`의 기본값 유실 문제 해결  
   - `@Builder.Default` 적용

3. 불필요한 voicefeedback 코드 제거  
   - 사용하지 않는 클래스/파일 정리

---

## 🧪 테스트

- 로컬 테스트를 통해 scriptId 기반 단건 연습 조회 정상 동작 확인
- Member builder 테스트 코드에서도 기본값 유지 확인

---

## ✅ 기타

- 클라이언트 연동 시, 단건 연습 조회 요청을 다음과 같은 형식으로 변경해야 합니다:  
  `GET /api/practices/single?scriptId=1`