### PR TITLE
31 feature/oauth kakao

### DIFF
--- a/src/main/java/com/_ithon/speeksee/domain/member/controller/AdditionalInfoRequestDto.java
+++ b/src/main/java/com/_ithon/speeksee/domain/member/controller/AdditionalInfoRequestDto.java
@@ -1,0 +1,27 @@
+package com._ithon.speeksee.domain.member.controller;
+
+import java.time.LocalDate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "소셜 사용자 추가 정보 입력 DTO")
+public class AdditionalInfoRequestDto {
+
+	@Schema(description = "닉네임", example = "ayla123")
+	@NotBlank
+	private String nickname;
+
+	@Schema(description = "생년월일 (yyyy-MM-dd)", example = "2005-07-01")
+	@NotNull
+	private LocalDate birthdate;
+
+}

--- a/src/main/java/com/_ithon/speeksee/domain/member/controller/MemberController.java
+++ b/src/main/java/com/_ithon/speeksee/domain/member/controller/MemberController.java
@@ -7,6 +7,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +18,7 @@ import com._ithon.speeksee.domain.member.dto.request.SignUpRequestDto;
 import com._ithon.speeksee.domain.member.dto.response.MemberInfoResponseDto;
 import com._ithon.speeksee.domain.member.entity.Member;
 import com._ithon.speeksee.domain.member.service.MemberService;
+import com._ithon.speeksee.global.auth.dto.response.LoginResponseDto;
 import com._ithon.speeksee.global.auth.model.CustomUserDetails;
 import com._ithon.speeksee.global.infra.exception.response.ApiRes;
 
@@ -24,6 +27,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -46,6 +51,16 @@ public class MemberController {
 		String username = userDetails.getUsername(); // 또는 email
 		Member member = memberService.findByEmail(username); // DB에서 조회
 		MemberInfoResponseDto response = memberService.getMyInfo(member);
+		return ResponseEntity.ok(ApiRes.success(response));
+	}
+
+	@Operation(summary = "추가 정보 입력", description = "소셜 로그인 후 부족한 정보를 입력합니다.")
+	@PatchMapping("/me/additional-info")
+	public ResponseEntity<ApiRes<MemberInfoResponseDto>> completeAdditionalInfo(
+		@AuthenticationPrincipal CustomUserDetails userDetails, // 또는 JWT에서 추출
+		@RequestBody @Valid AdditionalInfoRequestDto dto
+	) {
+		MemberInfoResponseDto response = memberService.completeAdditionalInfo(userDetails.getUsername(), dto);
 		return ResponseEntity.ok(ApiRes.success(response));
 	}
 }

--- a/src/main/java/com/_ithon/speeksee/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/_ithon/speeksee/domain/member/dto/request/SignUpRequestDto.java
@@ -42,6 +42,7 @@ public class SignUpRequestDto {
 			.currentLevel("초급")
 			.totalExp(0)
 			.consecutiveDays(0)
+			.isInfoCompleted(true)
 			.build();
 	}
 }

--- a/src/main/java/com/_ithon/speeksee/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/_ithon/speeksee/domain/member/dto/request/SignUpRequestDto.java
@@ -42,7 +42,7 @@ public class SignUpRequestDto {
 			.currentLevel("초급")
 			.totalExp(0)
 			.consecutiveDays(0)
-			.isInfoCompleted(true)
+			.infoCompleted(true)
 			.build();
 	}
 }

--- a/src/main/java/com/_ithon/speeksee/domain/member/dto/response/MemberInfoResponseDto.java
+++ b/src/main/java/com/_ithon/speeksee/domain/member/dto/response/MemberInfoResponseDto.java
@@ -36,6 +36,9 @@ public class MemberInfoResponseDto {
 	@Schema(description = "연속 출석 일수", example = "5")
 	private final Integer consecutiveDays;
 
+	@Schema(description = "추가정보(닉네임, 생년월일)을 입력이 필요한지 나타내는 flag", example = "true")
+	private final boolean infoCompleted;
+
 	@Schema(description = "계정 생성일시", example = "2025-06-20T10:00:00Z", required = false)
 	private final LocalDateTime createdAt;  // 로그인 시점에는 null이어도 됨
 
@@ -48,6 +51,7 @@ public class MemberInfoResponseDto {
 			.currentLevel(member.getCurrentLevel())
 			.totalExp(member.getTotalExp())
 			.consecutiveDays(member.getConsecutiveDays())
+			.infoCompleted(member.isInfoCompleted())
 			.createdAt(member.getCreatedAt())
 			.build();
 	}

--- a/src/main/java/com/_ithon/speeksee/domain/member/entity/Member.java
+++ b/src/main/java/com/_ithon/speeksee/domain/member/entity/Member.java
@@ -62,6 +62,8 @@ public class Member extends BaseTimeEntity {
 
 	private Integer consecutiveDays;
 
+	private boolean isInfoCompleted; // 추가 정보가 입력되었는지
+
 	@OneToMany(mappedBy = "author", cascade = CascadeType.ALL, orphanRemoval = true)
 	@Builder.Default
 	private List<Script> scripts = new ArrayList<>();

--- a/src/main/java/com/_ithon/speeksee/domain/member/entity/Member.java
+++ b/src/main/java/com/_ithon/speeksee/domain/member/entity/Member.java
@@ -62,7 +62,14 @@ public class Member extends BaseTimeEntity {
 
 	private Integer consecutiveDays;
 
+	@Builder.Default
 	private boolean isInfoCompleted = false; // 추가 정보가 입력되었는지
+
+	public void completeAdditionalInfo(String nickname, LocalDate birthday) {
+		this.nickname = nickname;
+		this.birthday = birthday;
+		this.isInfoCompleted = true;
+	}
 
 	@OneToMany(mappedBy = "author", cascade = CascadeType.ALL, orphanRemoval = true)
 	@Builder.Default

--- a/src/main/java/com/_ithon/speeksee/domain/member/entity/Member.java
+++ b/src/main/java/com/_ithon/speeksee/domain/member/entity/Member.java
@@ -63,12 +63,12 @@ public class Member extends BaseTimeEntity {
 	private Integer consecutiveDays;
 
 	@Builder.Default
-	private boolean isInfoCompleted = false; // 추가 정보가 입력되었는지
+	private boolean infoCompleted = false; // 추가 정보가 입력되었는지
 
 	public void completeAdditionalInfo(String nickname, LocalDate birthday) {
 		this.nickname = nickname;
 		this.birthday = birthday;
-		this.isInfoCompleted = true;
+		this.infoCompleted = true;
 	}
 
 	@OneToMany(mappedBy = "author", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/_ithon/speeksee/domain/member/entity/Member.java
+++ b/src/main/java/com/_ithon/speeksee/domain/member/entity/Member.java
@@ -62,7 +62,7 @@ public class Member extends BaseTimeEntity {
 
 	private Integer consecutiveDays;
 
-	private boolean isInfoCompleted; // 추가 정보가 입력되었는지
+	private boolean isInfoCompleted = false; // 추가 정보가 입력되었는지
 
 	@OneToMany(mappedBy = "author", cascade = CascadeType.ALL, orphanRemoval = true)
 	@Builder.Default

--- a/src/main/java/com/_ithon/speeksee/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/_ithon/speeksee/domain/member/repository/MemberRepository.java
@@ -16,4 +16,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	// 이메일 중복 확인
 	boolean existsByEmail(String email);
+
+	boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/_ithon/speeksee/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/_ithon/speeksee/domain/member/repository/MemberRepository.java
@@ -5,11 +5,14 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com._ithon.speeksee.domain.member.entity.AuthProvider;
 import com._ithon.speeksee.domain.member.entity.Member;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByEmail(String email);
+
+	Optional<Member> findByProviderIdAndAuthProvider(String providerId, AuthProvider provider);
 
 	// 이메일 중복 확인
 	boolean existsByEmail(String email);

--- a/src/main/java/com/_ithon/speeksee/domain/member/service/MemberService.java
+++ b/src/main/java/com/_ithon/speeksee/domain/member/service/MemberService.java
@@ -1,17 +1,21 @@
 package com._ithon.speeksee.domain.member.service;
 
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com._ithon.speeksee.domain.member.controller.AdditionalInfoRequestDto;
 import com._ithon.speeksee.domain.member.dto.request.SignUpRequestDto;
 import com._ithon.speeksee.domain.member.dto.response.MemberInfoResponseDto;
 import com._ithon.speeksee.domain.member.entity.Member;
 import com._ithon.speeksee.domain.member.repository.MemberRepository;
 import com._ithon.speeksee.global.infra.exception.auth.SpeekseeAuthException;
+import com._ithon.speeksee.global.infra.exception.entityException.MemberNotFoundException;
+import com.google.api.gax.rpc.NotFoundException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,4 +35,13 @@ public class MemberService {
 		return memberRepository.findByEmail(email)
 			.orElseThrow(() -> new NoSuchElementException("존재하지 않는 이메일입니다: " + email));
 	}
+
+	@Transactional
+	public MemberInfoResponseDto completeAdditionalInfo(String email, AdditionalInfoRequestDto dto) {
+		Member member = memberRepository.findByEmail(email)
+			.orElseThrow(MemberNotFoundException::new);
+		member.completeAdditionalInfo(dto.getNickname(), dto.getBirthdate());
+		return MemberInfoResponseDto.from(member);
+	}
+
 }

--- a/src/main/java/com/_ithon/speeksee/domain/member/service/MemberService.java
+++ b/src/main/java/com/_ithon/speeksee/domain/member/service/MemberService.java
@@ -14,6 +14,7 @@ import com._ithon.speeksee.domain.member.dto.response.MemberInfoResponseDto;
 import com._ithon.speeksee.domain.member.entity.Member;
 import com._ithon.speeksee.domain.member.repository.MemberRepository;
 import com._ithon.speeksee.global.infra.exception.auth.SpeekseeAuthException;
+import com._ithon.speeksee.global.infra.exception.entityException.DuplicateResourceException;
 import com._ithon.speeksee.global.infra.exception.entityException.MemberNotFoundException;
 import com.google.api.gax.rpc.NotFoundException;
 
@@ -40,6 +41,12 @@ public class MemberService {
 	public MemberInfoResponseDto completeAdditionalInfo(String email, AdditionalInfoRequestDto dto) {
 		Member member = memberRepository.findByEmail(email)
 			.orElseThrow(MemberNotFoundException::new);
+
+		// 닉네임 중복 체크
+		if (memberRepository.existsByNickname(dto.getNickname())) {
+			throw new DuplicateResourceException("닉네임", dto.getNickname());
+		}
+
 		member.completeAdditionalInfo(dto.getNickname(), dto.getBirthdate());
 		return MemberInfoResponseDto.from(member);
 	}

--- a/src/main/java/com/_ithon/speeksee/domain/member/service/MemberSignupService.java
+++ b/src/main/java/com/_ithon/speeksee/domain/member/service/MemberSignupService.java
@@ -8,6 +8,7 @@ import com._ithon.speeksee.domain.member.dto.request.SignUpRequestDto;
 import com._ithon.speeksee.domain.member.entity.Member;
 import com._ithon.speeksee.domain.member.repository.MemberRepository;
 import com._ithon.speeksee.global.infra.exception.auth.SpeekseeAuthException;
+import com._ithon.speeksee.global.infra.exception.entityException.DuplicateResourceException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,11 +20,11 @@ public class MemberSignupService {
 
 	public Member signUp(SignUpRequestDto signUpRequestDto) {
 		if (memberRepository.existsByEmail(signUpRequestDto.getEmail())) {
-			throw new SpeekseeAuthException(HttpStatus.CONFLICT, "이메일이 이미 존재합니다");
+			throw new DuplicateResourceException("이메일", signUpRequestDto.getEmail());
 		}
 
 		if (memberRepository.existsByNickname(signUpRequestDto.getNickname())) {
-			throw new SpeekseeAuthException(HttpStatus.CONFLICT, "닉네임이 이미 사용 중입니다");
+			throw new DuplicateResourceException("닉네임", signUpRequestDto.getNickname());
 		}
 
 		String encodedPassword = passwordEncoder.encode(signUpRequestDto.getPassword());

--- a/src/main/java/com/_ithon/speeksee/domain/member/service/MemberSignupService.java
+++ b/src/main/java/com/_ithon/speeksee/domain/member/service/MemberSignupService.java
@@ -22,6 +22,10 @@ public class MemberSignupService {
 			throw new SpeekseeAuthException(HttpStatus.CONFLICT, "이메일이 이미 존재합니다");
 		}
 
+		if (memberRepository.existsByNickname(signUpRequestDto.getNickname())) {
+			throw new SpeekseeAuthException(HttpStatus.CONFLICT, "닉네임이 이미 사용 중입니다");
+		}
+
 		String encodedPassword = passwordEncoder.encode(signUpRequestDto.getPassword());
 
 		Member member = signUpRequestDto.toEntity(encodedPassword);

--- a/src/main/java/com/_ithon/speeksee/global/auth/controller/AuthController.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/controller/AuthController.java
@@ -3,7 +3,6 @@ package com._ithon.speeksee.global.auth.controller;
 import java.time.Duration;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,16 +15,11 @@ import com._ithon.speeksee.global.auth.dto.request.RefreshTokenRequestDto;
 import com._ithon.speeksee.global.auth.dto.response.AccessTokenResponseDto;
 import com._ithon.speeksee.global.auth.dto.response.LoginResponseDto;
 import com._ithon.speeksee.global.auth.jwt.JwtTokenProvider;
-import com._ithon.speeksee.global.auth.dto.request.GoogleOAuthRequestDto;
-import com._ithon.speeksee.global.auth.service.OAuth2LoginService;
 import com._ithon.speeksee.global.auth.service.AuthService;
-import com._ithon.speeksee.global.infra.exception.auth.SpeekseeAuthException;
-import com._ithon.speeksee.global.infra.exception.code.ErrorCode;
 import com._ithon.speeksee.global.infra.exception.response.ApiRes;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;

--- a/src/main/java/com/_ithon/speeksee/global/auth/controller/OAuthController.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/controller/OAuthController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com._ithon.speeksee.global.auth.dto.request.GoogleOAuthRequestDto;
+import com._ithon.speeksee.global.auth.dto.request.OAuthRequestDto;
 import com._ithon.speeksee.global.auth.dto.response.LoginResponseDto;
 import com._ithon.speeksee.global.auth.service.OAuth2LoginService;
 import com._ithon.speeksee.global.infra.exception.auth.SpeekseeAuthException;
@@ -15,12 +15,12 @@ import com._ithon.speeksee.global.infra.exception.code.ErrorCode;
 import com._ithon.speeksee.global.infra.exception.response.ApiRes;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
 
 @Tag(name = "OAuth2 로그인", description = "OAuth2를 활용한 소셜 로그인 API")
 @RestController
@@ -30,39 +30,16 @@ public class OAuthController {
 
 	private final OAuth2LoginService oAuth2LoginService;
 
-
-	@Operation(summary = "Google 로그인", description = "Google OAuth2 인가 코드를 이용하여 로그인하고 JWT 토큰을 반환합니다 - 성공 응답은 기본 로그인과 같습니다"
-
-	)
+	@Operation(summary = "OAuth 소셜 로그인", description = "KAKAO, GOOGLE OAuth 로그인")
 	@ApiResponses(value = {
 		@ApiResponse(
-			responseCode = "200", description = "Google 로그인 성공"
+			responseCode = "200", description = "소셜 로그인 성공"
 		)
 	})
-	@PostMapping("/google")
-	public ResponseEntity<ApiRes<LoginResponseDto>> googleLogin(@RequestBody GoogleOAuthRequestDto request) {
-		try {
-			LoginResponseDto response = oAuth2LoginService.loginWithGoogle(request.getCode());
-			return ResponseEntity.ok(ApiRes.success(response, "Google 로그인 성공"));
-
-		} catch (SpeekseeAuthException e) {
-
-			return ResponseEntity
-				.status(e.getStatus())
-				.body(ApiRes.failure(e.getStatus(), e.getMessage(), ErrorCode.AUTH_FAIL));
-
-		} catch (IllegalArgumentException | NullPointerException e) {
-
-			return ResponseEntity
-				.badRequest()
-				.body(ApiRes.failure(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 코드입니다.", ErrorCode.AUTH_FAIL));
-
-		} catch (Exception e) {
-
-			return ResponseEntity
-				.status(HttpStatus.INTERNAL_SERVER_ERROR)
-				.body(ApiRes.failure(HttpStatus.INTERNAL_SERVER_ERROR, "Google 로그인 처리 중 오류가 발생했습니다.",
-					ErrorCode.INTERNAL_ERROR));
-		}
+	@PostMapping("/login")
+	public ResponseEntity<ApiRes<LoginResponseDto>> loginWithOAuth2(@RequestBody @Valid OAuthRequestDto request) {
+		LoginResponseDto response = oAuth2LoginService.login(request.getCode(), request.getProvider());
+		return ResponseEntity.ok(ApiRes.success(response, "소셜 로그인 성공"));
 	}
+
 }

--- a/src/main/java/com/_ithon/speeksee/global/auth/dto/request/GoogleOAuthRequestDto.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/dto/request/GoogleOAuthRequestDto.java
@@ -1,8 +1,0 @@
-package com._ithon.speeksee.global.auth.dto.request;
-
-import lombok.Getter;
-
-@Getter
-public class GoogleOAuthRequestDto {
-	private String code;
-}

--- a/src/main/java/com/_ithon/speeksee/global/auth/dto/request/OAuthRequestDto.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/dto/request/OAuthRequestDto.java
@@ -1,0 +1,11 @@
+package com._ithon.speeksee.global.auth.dto.request;
+
+import com._ithon.speeksee.domain.member.entity.AuthProvider;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthRequestDto {
+	private String code;
+	private AuthProvider provider;
+}

--- a/src/main/java/com/_ithon/speeksee/global/auth/dto/request/OAuthRequestDto.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/dto/request/OAuthRequestDto.java
@@ -2,10 +2,16 @@ package com._ithon.speeksee.global.auth.dto.request;
 
 import com._ithon.speeksee.domain.member.entity.AuthProvider;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
+@Schema(description = "소셜 로그인 요청 DTO")
 public class OAuthRequestDto {
+
+	@Schema(description = "소셜 인가 코드", example = "abc123code...")
 	private String code;
+
+	@Schema(description = "소셜 로그인 공급자", example = "KAKAO")
 	private AuthProvider provider;
 }

--- a/src/main/java/com/_ithon/speeksee/global/auth/dto/response/GoogleUserInfo.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/dto/response/GoogleUserInfo.java
@@ -2,12 +2,14 @@ package com._ithon.speeksee.global.auth.dto.response;
 
 import java.util.Map;
 
+import com._ithon.speeksee.domain.member.entity.AuthProvider;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class GoogleUserInfoResponseDto implements OAuth2UserInfo {
+public class GoogleUserInfo implements OAuth2UserInfo {
 
 	private Map<String, Object> attributes;
 
@@ -17,12 +19,12 @@ public class GoogleUserInfoResponseDto implements OAuth2UserInfo {
 	}
 
 	@Override
-	public final String getName() {
-		return (String)attributes.get("name");
+	public String getId() {
+		return (String)attributes.get("id");
 	}
 
 	@Override
-	public final Map<String, Object> getAttributes() {
-		return attributes;
+	public AuthProvider getProvider() {
+		return AuthProvider.GOOGLE;
 	}
 }

--- a/src/main/java/com/_ithon/speeksee/global/auth/dto/response/KakaoUserInfo.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/dto/response/KakaoUserInfo.java
@@ -1,0 +1,33 @@
+package com._ithon.speeksee.global.auth.dto.response;
+
+import java.util.Map;
+
+import org.checkerframework.checker.units.qual.A;
+
+import com._ithon.speeksee.domain.member.entity.AuthProvider;
+
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class KakaoUserInfo implements OAuth2UserInfo {
+
+	private final Map<String, Object> attributes;
+
+	@Override
+	public String getEmail() { // 카카오는 kakao_account{email:..} 이렇게 주더라 -> 중첩구조라 꺼내써야됨
+		Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
+		return kakaoAccount != null ? (String)kakaoAccount.get("email") : null;
+	}
+
+	@Override
+	public String getId() { // 카카오는 id를 Long으로 줌
+		Object id = attributes.get("id");
+		return id != null ? String.valueOf(id) : null;
+	}
+
+	@Override
+	public AuthProvider getProvider() {
+		return AuthProvider.KAKAO;
+	}
+}

--- a/src/main/java/com/_ithon/speeksee/global/auth/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/dto/response/LoginResponseDto.java
@@ -24,6 +24,9 @@ public class LoginResponseDto {
 	@Schema(description = "로그인한 사용자 정보")
 	private final MemberInfoResponseDto memberInfo;
 
+	@Schema(description = "추가정보(닉네임, 생년월일)을 입력이 필요한지 나타내는 flag", example = "true")
+	private final boolean needsAdditionalInfo;
+
 	public static LoginResponseDto from(String accessToken, String refreshToken, long expiresIn,
 		MemberInfoResponseDto memberInfo) {
 		return LoginResponseDto.builder()
@@ -31,6 +34,13 @@ public class LoginResponseDto {
 			.refreshToken(refreshToken)
 			.expiresIn(expiresIn)
 			.memberInfo(memberInfo)
+			.needsAdditionalInfo(false)
 			.build();
+	}
+
+	// 추가 정보 필요 응답
+	public static LoginResponseDto needsAdditionalInfo(String accessToken, String refreshToken, long expiresIn,
+		MemberInfoResponseDto member) {
+		return new LoginResponseDto(accessToken, refreshToken, expiresIn, member, true);
 	}
 }

--- a/src/main/java/com/_ithon/speeksee/global/auth/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/dto/response/LoginResponseDto.java
@@ -1,6 +1,7 @@
 package com._ithon.speeksee.global.auth.dto.response;
 
 import com._ithon.speeksee.domain.member.dto.response.MemberInfoResponseDto;
+import com._ithon.speeksee.domain.member.entity.Member;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -24,23 +25,12 @@ public class LoginResponseDto {
 	@Schema(description = "로그인한 사용자 정보")
 	private final MemberInfoResponseDto memberInfo;
 
-	@Schema(description = "추가정보(닉네임, 생년월일)을 입력이 필요한지 나타내는 flag", example = "true")
-	private final boolean needsAdditionalInfo;
-
-	public static LoginResponseDto from(String accessToken, String refreshToken, long expiresIn,
-		MemberInfoResponseDto memberInfo) {
+	public static LoginResponseDto of(String accessToken, String refreshToken, long expiresIn, Member member) {
 		return LoginResponseDto.builder()
 			.accessToken(accessToken)
 			.refreshToken(refreshToken)
 			.expiresIn(expiresIn)
-			.memberInfo(memberInfo)
-			.needsAdditionalInfo(false)
+			.memberInfo(MemberInfoResponseDto.from(member))
 			.build();
-	}
-
-	// 추가 정보 필요 응답
-	public static LoginResponseDto needsAdditionalInfo(String accessToken, String refreshToken, long expiresIn,
-		MemberInfoResponseDto member) {
-		return new LoginResponseDto(accessToken, refreshToken, expiresIn, member, true);
 	}
 }

--- a/src/main/java/com/_ithon/speeksee/global/auth/dto/response/OAuth2UserInfo.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/dto/response/OAuth2UserInfo.java
@@ -2,8 +2,21 @@ package com._ithon.speeksee.global.auth.dto.response;
 
 import java.util.Map;
 
+import com._ithon.speeksee.domain.member.entity.AuthProvider;
+
 public interface OAuth2UserInfo {
+
 	String getEmail();
-	String getName();
-	Map<String, Object> getAttributes();
+
+	String getId();
+
+	AuthProvider getProvider();
+
+	static OAuth2UserInfo of(AuthProvider authProvider, Map<String, Object> attributes) {
+		return switch (authProvider) {
+			case KAKAO -> new KakaoUserInfo(attributes);
+			case GOOGLE -> new GoogleUserInfo(attributes);
+			default -> throw new IllegalArgumentException("지원하지 않는 OAuth 공급자입니다: " + authProvider);
+		};
+	}
 }

--- a/src/main/java/com/_ithon/speeksee/global/auth/jwt/LoginFilter.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/jwt/LoginFilter.java
@@ -5,7 +5,9 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Map;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.DisabledException;
@@ -27,6 +29,7 @@ import com._ithon.speeksee.global.infra.exception.response.ApiRes;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -76,6 +79,16 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 		// 리프레쉬 토큰 저장
 		RefreshToken refreshTokenEntity = buildRefreshTokenEntity(refreshToken, member);
 		refreshTokenRepository.save(refreshTokenEntity);
+
+		// refresh token을 HTTP-only 쿠키로 설정
+		ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
+			.httpOnly(true)
+			.secure(false) // ⚠️ 배포 시 true
+			.sameSite("Lax")
+			.path("/")
+			.maxAge(Duration.ofDays(14))
+			.build();
+		response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
 		// 응답 DTO
 		MemberInfoResponseDto memberInfo = buildMemberInfoDto(member);

--- a/src/main/java/com/_ithon/speeksee/global/auth/jwt/LoginFilter.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/jwt/LoginFilter.java
@@ -62,6 +62,10 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 		Member member = userDetails.getMember();
 		String email = userDetails.getUsername(); // 이메일값임
 
+		if (!member.isInfoCompleted()) {
+			throw new IllegalStateException("폼 로그인 사용자는 추가 정보가 모두 입력되어 있어야 합니다.");
+		}
+
 		// 토큰 생성
 		String accessToken = jwtTokenProvider.generateAccessToken(email);
 		String refreshToken = jwtTokenProvider.generateRefreshToken(email);

--- a/src/main/java/com/_ithon/speeksee/global/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/service/AuthServiceImpl.java
@@ -54,10 +54,7 @@ public class AuthServiceImpl implements AuthService {
 		// 5. access token 만료 시간 (예: ms 단위 → s 단위 변환)
 		int expiresIn = (int)(jwtTokenProvider.getAccessTokenExpirationMs() / 1000); // 또는 직접 상수로 설정 가능
 
-		// 6. 사용자 정보를 DTO로 변환
-		MemberInfoResponseDto memberInfoDto = MemberInfoResponseDto.from(member);
-
-		return LoginResponseDto.from(accessToken, refreshTokenValue, expiresIn, memberInfoDto);
+		return LoginResponseDto.of(accessToken, refreshTokenValue, expiresIn, member);
 	}
 
 	@Override
@@ -76,9 +73,7 @@ public class AuthServiceImpl implements AuthService {
 
 		int expiresIn = (int)(jwtTokenProvider.getAccessTokenExpirationMs() / 1000);
 
-		MemberInfoResponseDto memberInfoDto = MemberInfoResponseDto.from(member);
-
-		return LoginResponseDto.from(accessToken, refreshTokenValue, expiresIn, memberInfoDto);
+		return LoginResponseDto.of(accessToken, refreshTokenValue, expiresIn, member);
 	}
 
 	@Override
@@ -118,9 +113,8 @@ public class AuthServiceImpl implements AuthService {
 		refreshTokenRepository.save(newToken);
 
 		int expiresIn = (int)(jwtTokenProvider.getAccessTokenExpirationMs() / 1000);
-		MemberInfoResponseDto memberInfoDto = MemberInfoResponseDto.from(member);
 
-		return LoginResponseDto.from(newAccessToken, newRefreshToken, expiresIn, memberInfoDto);
+		return LoginResponseDto.of(newAccessToken, newRefreshToken, expiresIn, member);
 	}
 
 	// @Override

--- a/src/main/java/com/_ithon/speeksee/global/auth/service/KakaoOAuth2Client.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/service/KakaoOAuth2Client.java
@@ -2,7 +2,7 @@ package com._ithon.speeksee.global.auth.service;
 
 import java.util.Map;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -15,89 +15,88 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import com._ithon.speeksee.domain.member.entity.AuthProvider;
-import com._ithon.speeksee.global.auth.dto.response.GoogleUserInfo;
+import com._ithon.speeksee.global.auth.dto.response.KakaoUserInfo;
 import com._ithon.speeksee.global.auth.dto.response.OAuth2UserInfo;
 import com._ithon.speeksee.global.infra.exception.auth.SpeekseeAuthException;
+
+import org.springframework.beans.factory.annotation.Value;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@RequiredArgsConstructor
 @Component
+@RequiredArgsConstructor
 @Slf4j
-public class GoogleOAuth2Client implements OAuth2Client {
+public class KakaoOAuth2Client implements OAuth2Client {
 
-	@Value("${oauth.google.client-id}")
+	@Value("${oauth.kakao.client-id}")
 	private String clientId;
 
-	@Value("${oauth.google.client-secret}")
-	private String clientSecret;
-
-	@Value("${oauth.google.redirect-uri}")
+	@Value("${oauth.kakao.redirect-uri}")
 	private String redirectUri;
 
-	private final RestTemplate restTemplate = new RestTemplate(); //외부 API 서버와 데이터를 주고받을 때 주로 사용
+	@Value("${oauth.kakao.client-secret}")
+	private String clientSecret;
 
+	protected final RestTemplate restTemplate = new RestTemplate();
+
+	@Override
 	public String getAccessToken(String code) {
-		String tokenUrl = "https://oauth2.googleapis.com/token";
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED); // 구글이 이 형식을 원함
-
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-		params.add("code", code);
 		params.add("client_id", clientId);
-		params.add("client_secret", clientSecret);
 		params.add("redirect_uri", redirectUri);
+		params.add("client_secret", clientSecret);
+		params.add("code", code);
 		params.add("grant_type", "authorization_code");
 
-		// // 로그 출력
-		// log.info("OAuth Token Request Parameters:");
-		// log.info("code = {}", code);
-		// log.info("client_id = {}", clientId);
-		// log.info("redirect_uri = {}", redirectUri);
-		// log.info("grant_type = authorization_code");
+		log.info("OAuth Token Request Parameters:");
+		log.info("code = {}", code);
+		log.info("client_id = {}", clientId);
+		log.info("redirect_uri = {}", redirectUri);
 
-		HttpEntity<?> request = new HttpEntity<>(params, headers);
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
 
-		// 서버에 post 요청을 보냄
 		ResponseEntity<Map> response = restTemplate.postForEntity(
-			"https://oauth2.googleapis.com/token", request, Map.class);
+			"https://kauth.kakao.com/oauth/token", request, Map.class
+		);
 
-		// 구글로부터 받은 access token
 		if (response.getStatusCode() == HttpStatus.OK) {
 			return (String)response.getBody().get("access_token");
 		} else {
 			throw new SpeekseeAuthException(HttpStatus.BAD_REQUEST, "Google OAuth2 토큰 요청 실패: " + response);
 		}
+
 	}
 
 	// 받은 accessToken으로 사용자 정보 요청
+	@Override
 	public OAuth2UserInfo getUserInfo(String accessToken) {
-		String userInfoUrl = "https://www.googleapis.com/oauth2/v2/userinfo";
-
+		String userInfoUrl = "https://kapi.kakao.com/v2/user/me";
 		HttpHeaders headers = new HttpHeaders();
 		headers.setBearerAuth(accessToken);
 
-		HttpEntity<?> entity = new HttpEntity<>(headers);
-
-		ResponseEntity<Map> response = restTemplate.exchange(
+		ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
 			userInfoUrl,
 			HttpMethod.GET,
-			entity,
-			Map.class
+			new HttpEntity<>(headers),
+			new ParameterizedTypeReference<Map<String, Object>>() {
+			}
 		);
 
 		if (response.getStatusCode() != HttpStatus.OK) {
-			throw new RuntimeException("Google 사용자 정보 요청 실패: " + response);
+			throw new SpeekseeAuthException(HttpStatus.UNAUTHORIZED, "카카오 사용자 정보 요청 실패");
 		}
 
+		log.info("response code = {}", response.getBody());
+
 		Map<String, Object> attributes = response.getBody();
-		return OAuth2UserInfo.of(AuthProvider.GOOGLE, attributes);
+		return OAuth2UserInfo.of(AuthProvider.KAKAO, attributes);
 	}
 
 	@Override
 	public AuthProvider getProvider() {
-		return AuthProvider.GOOGLE;
+		return AuthProvider.KAKAO;
 	}
 }

--- a/src/main/java/com/_ithon/speeksee/global/auth/service/OAuth2Client.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/service/OAuth2Client.java
@@ -1,0 +1,12 @@
+package com._ithon.speeksee.global.auth.service;
+
+import com._ithon.speeksee.domain.member.entity.AuthProvider;
+import com._ithon.speeksee.global.auth.dto.response.OAuth2UserInfo;
+
+public interface OAuth2Client {
+	String getAccessToken(String code);
+
+	OAuth2UserInfo getUserInfo(String accessToken);
+
+	AuthProvider getProvider();
+}

--- a/src/main/java/com/_ithon/speeksee/global/auth/service/OAuth2LoginService.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/service/OAuth2LoginService.java
@@ -1,13 +1,14 @@
 package com._ithon.speeksee.global.auth.service;
 
-import java.util.Map;
+import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
+import com._ithon.speeksee.domain.member.dto.response.MemberInfoResponseDto;
 import com._ithon.speeksee.domain.member.entity.AuthProvider;
 import com._ithon.speeksee.domain.member.entity.Member;
 import com._ithon.speeksee.global.auth.dto.response.LoginResponseDto;
-import com._ithon.speeksee.global.auth.dto.response.GoogleUserInfoResponseDto;
 import com._ithon.speeksee.global.auth.dto.response.OAuth2UserInfo;
 
 import lombok.RequiredArgsConstructor;
@@ -18,26 +19,43 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class OAuth2LoginService {
 
-	private final GoogleOAuth2Client googleOAuth2Client;
+	private final List<OAuth2Client> clients;
 	private final OAuthService oAuthService;
 	private final AuthService authService;
 
-	public LoginResponseDto loginWithGoogle(String code) {
-		//  access_token
-		String accessToken = googleOAuth2Client.getAccessToken(code);
+	public LoginResponseDto login(String code, AuthProvider authProvider) {
 
-		// access_token → 사용자 정보
-		Map<String, Object> attributes = googleOAuth2Client.getUserInfo(accessToken);
+		OAuth2Client client = clients.stream()
+			.filter(c -> c.getProvider() == authProvider) // fe에서 준 authProvider랑 맞는거만 통과
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("지원하지 않는 OAuth 공급자입니다: " + authProvider));
 
-		log.info("attrivure = {}", attributes);
+		String accessToken = client.getAccessToken(code);
+		OAuth2UserInfo userInfo = client.getUserInfo(accessToken);
 
-		// userInfo 파싱
-		OAuth2UserInfo userInfo = new GoogleUserInfoResponseDto(attributes);
+		log.info("소셜 로그인 시도: provider={}, email={}", authProvider, userInfo.getEmail());
 
-		// 회원 조회 or 자동 가입
-		Member member = oAuthService.findOrCreate(userInfo, AuthProvider.GOOGLE);
+		// providerId + provider으로 기존 회원 조회
+		Optional<Member> optionalMember = oAuthService.findByProviderIdAndProvider(userInfo.getId(), authProvider);
 
-		// JWT 발급 + 로그인 응답 생성
+		// 신규 회원 생성 또는 기존 회원 반환
+		Member member = optionalMember.orElseGet(() ->
+			oAuthService.findOrCreate(userInfo, authProvider)
+		);
+
+		// 추가 정보가 없으면, 추가 정보가 필요
+		if (!member.isInfoCompleted()) {
+			LoginResponseDto tokens = authService.login(member);
+
+			return LoginResponseDto.needsAdditionalInfo(
+				tokens.getAccessToken(),
+				tokens.getRefreshToken(),
+				tokens.getExpiresIn(),
+				MemberInfoResponseDto.from(member)
+			);
+		}
+
+		// 로그인 -> jwt 발급
 		return authService.login(member);
 	}
 }

--- a/src/main/java/com/_ithon/speeksee/global/auth/service/OAuth2LoginService.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/service/OAuth2LoginService.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
+import com._ithon.speeksee.domain.attendance.service.AttendanceService;
 import com._ithon.speeksee.domain.member.dto.response.MemberInfoResponseDto;
 import com._ithon.speeksee.domain.member.entity.AuthProvider;
 import com._ithon.speeksee.domain.member.entity.Member;
@@ -22,6 +23,7 @@ public class OAuth2LoginService {
 	private final List<OAuth2Client> clients;
 	private final OAuthService oAuthService;
 	private final AuthService authService;
+	private final AttendanceService attendanceService;
 
 	public LoginResponseDto login(String code, AuthProvider authProvider) {
 
@@ -54,6 +56,9 @@ public class OAuth2LoginService {
 				MemberInfoResponseDto.from(member)
 			);
 		}
+
+		// 출석
+		attendanceService.attend(member);
 
 		// 로그인 -> jwt 발급
 		return authService.login(member);

--- a/src/main/java/com/_ithon/speeksee/global/auth/service/OAuth2LoginService.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/service/OAuth2LoginService.java
@@ -44,21 +44,21 @@ public class OAuth2LoginService {
 		Member member = optionalMember.orElseGet(() ->
 			oAuthService.findOrCreate(userInfo, authProvider)
 		);
+		
+		// 출석
+		attendanceService.attend(member);
 
 		// 추가 정보가 없으면, 추가 정보가 필요
 		if (!member.isInfoCompleted()) {
 			LoginResponseDto tokens = authService.login(member);
 
-			return LoginResponseDto.needsAdditionalInfo(
+			return LoginResponseDto.of(
 				tokens.getAccessToken(),
 				tokens.getRefreshToken(),
 				tokens.getExpiresIn(),
-				MemberInfoResponseDto.from(member)
+				member
 			);
 		}
-
-		// 출석
-		attendanceService.attend(member);
 
 		// 로그인 -> jwt 발급
 		return authService.login(member);

--- a/src/main/java/com/_ithon/speeksee/global/auth/service/OAuthService.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/service/OAuthService.java
@@ -48,7 +48,7 @@ public class OAuthService {
 			.email(userInfo.getEmail())
 			.authProvider(provider)
 			.providerId(userInfo.getId())
-			.isInfoCompleted(false)
+			.infoCompleted(false)
 			.build();
 
 		return memberRepository.save(member);

--- a/src/main/java/com/_ithon/speeksee/global/auth/service/OAuthService.java
+++ b/src/main/java/com/_ithon/speeksee/global/auth/service/OAuthService.java
@@ -1,5 +1,7 @@
 package com._ithon.speeksee.global.auth.service;
 
+import java.util.Optional;
+
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.stereotype.Service;
 
@@ -18,28 +20,41 @@ public class OAuthService {
 
 	private final MemberRepository memberRepository;
 
+	/**
+	 * 소셜 로그인 사용자 처리: 이메일 기준으로 기존 회원인지 판단하고,
+	 * provider 불일치 시 예외, 없으면 신규 등록
+	 */
 	public Member findOrCreate(OAuth2UserInfo userInfo, AuthProvider provider) {
 		String email = userInfo.getEmail();
 
 		return memberRepository.findByEmail(email)
 			.map(existing -> {
-				// 이미 존재하는데 provider가 다르면 예외 처리
-				if (!existing.getAuthProvider().equals(provider)) {
-					throw new OAuth2AuthenticationException("다른 소셜 계정으로 가입된 이메일입니다.");
-				}
+				validateProviderMatch(existing, provider);
 				return existing;
 			})
 			.orElseGet(() -> registerNewUser(userInfo, provider));
 	}
 
+	private void validateProviderMatch(Member existing, AuthProvider provider) {
+		if (!existing.getAuthProvider().equals(provider)) {
+			throw new OAuth2AuthenticationException(
+				String.format("해당 이메일은 이미 %s 계정으로 가입되어 있습니다.", existing.getAuthProvider().name()));
+		}
+	}
+
 	private Member registerNewUser(OAuth2UserInfo userInfo, AuthProvider provider) {
-		log.info("registerNewUser");
-		log.info("userInfo: {}", userInfo.getEmail());
+		log.info("신규 사용자 등록 - email: {}, provider: {}", userInfo.getEmail(), provider);
 		Member member = Member.builder()
 			.email(userInfo.getEmail())
 			.authProvider(provider)
+			.providerId(userInfo.getId())
+			.isInfoCompleted(false)
 			.build();
 
 		return memberRepository.save(member);
+	}
+
+	public Optional<Member> findByProviderIdAndProvider(String providerId, AuthProvider provider) {
+		return memberRepository.findByProviderIdAndAuthProvider(providerId, provider);
 	}
 }

--- a/src/main/java/com/_ithon/speeksee/global/infra/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/_ithon/speeksee/global/infra/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com._ithon.speeksee.global.infra.exception.auth.OAuth2AuthenticationException;
 import com._ithon.speeksee.global.infra.exception.code.ErrorCode;
 import com._ithon.speeksee.global.infra.exception.entityException.MemberNotFoundException;
 import com._ithon.speeksee.global.infra.exception.entityException.PracticeNotFoundException;
@@ -71,6 +72,12 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(PracticeNotFoundException.class)
 	public ResponseEntity<ApiRes<Void>> handlePracticeNotFound(PracticeNotFoundException e) {
+		return ResponseEntity.status(e.getStatus())
+			.body(ApiRes.failure(e.getStatus(), e.getMessage(), e.getErrorCode()));
+	}
+
+	@ExceptionHandler(OAuth2AuthenticationException.class)
+	public ResponseEntity<ApiRes<Void>> handleOAuth2AuthException(OAuth2AuthenticationException e) {
 		return ResponseEntity.status(e.getStatus())
 			.body(ApiRes.failure(e.getStatus(), e.getMessage(), e.getErrorCode()));
 	}

--- a/src/main/java/com/_ithon/speeksee/global/infra/exception/auth/OAuth2AuthenticationException.java
+++ b/src/main/java/com/_ithon/speeksee/global/infra/exception/auth/OAuth2AuthenticationException.java
@@ -1,0 +1,13 @@
+package com._ithon.speeksee.global.infra.exception.auth;
+
+import org.springframework.http.HttpStatus;
+
+import com._ithon.speeksee.global.infra.exception.SpeekseeException;
+import com._ithon.speeksee.global.infra.exception.code.ErrorCode;
+
+public class OAuth2AuthenticationException extends SpeekseeException {
+
+	public OAuth2AuthenticationException() {
+		super(HttpStatus.UNAUTHORIZED, ErrorCode.OAUTH_AUTH_FAILED);
+	}
+}

--- a/src/main/java/com/_ithon/speeksee/global/infra/exception/code/ErrorCode.java
+++ b/src/main/java/com/_ithon/speeksee/global/infra/exception/code/ErrorCode.java
@@ -12,14 +12,13 @@ public enum ErrorCode {
 	NOT_FOUND(1003, "리소스를 찾을 수 없습니다."),
 	FORBIDDEN(1004, "권한이 올바르지 않습니다."),
 	INTERNAL_ERROR(1000, "서버 내부 오류"),
+	OAUTH_AUTH_FAILED(1005, "OAuth 인증에 실패했습니다."),
 
 	// --- 도메인 기반 상세 오류 ---
 	MEMBER_NOT_FOUND(2001, "해당 사용자를 찾을 수 없습니다."),
 	SCRIPT_GENERATION_FAILED(2002, "대본 생성에 실패했습니다."),
 	SCRIPT_NOT_FOUND(2003, "해당 대본을 찾을 수 없습니다."),
-	VOICE_FEEDBACK_INVALID(2004, "음성 피드백 요청이 유효하지 않습니다.")
-	,PraCTICE_NOT_FOUND(2005, "해당 연습을 찾을 수 없습니다.")
-	;
+	VOICE_FEEDBACK_INVALID(2004, "음성 피드백 요청이 유효하지 않습니다."), PraCTICE_NOT_FOUND(2005, "해당 연습을 찾을 수 없습니다.");
 
 	private final int code;
 	private final String message;

--- a/src/main/java/com/_ithon/speeksee/global/infra/exception/entityException/DuplicateResourceException.java
+++ b/src/main/java/com/_ithon/speeksee/global/infra/exception/entityException/DuplicateResourceException.java
@@ -1,0 +1,15 @@
+package com._ithon.speeksee.global.infra.exception.entityException;
+
+import org.springframework.http.HttpStatus;
+
+import com._ithon.speeksee.global.infra.exception.SpeekseeException;
+
+public class DuplicateResourceException extends SpeekseeException {
+	public DuplicateResourceException(String resourceName, String value) {
+		super(HttpStatus.CONFLICT, String.format("중복된 %s입니다: %s", resourceName, value));
+	}
+
+	public DuplicateResourceException(String message) {
+		super(HttpStatus.CONFLICT, message);
+	}
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -57,4 +57,9 @@ oauth:
   google:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
-    redirect-uri: ${REDIRECT_URL}
+    redirect-uri: ${GOOGLE_REDIRECT_URL}
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID}
+    client-secret: ${KAKAO_CLIENT_SECRET}
+    redirect-uri: ${KAKAO_REDIRECT_URL}
+

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -58,4 +58,7 @@ oauth:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
     redirect-uri: ${REDIRECT_URL}
-
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID}
+    client-secret: ${KAKAO_CLIENT_SECRET}
+    redirect-uri: ${KAKAO_REDIRECT_URL}


### PR DESCRIPTION
## 개요
소셜 로그인 + 추가 정보 입력 + 자동 출석 기능 통합

## 주요 변경 사항
1. OAuth2 로그인 구현
- 카카오, 구글 등 소셜 로그인 공급자별 OAuth2Client 전략 패턴 적용
- Auth2LoginService에서 공급자 분기에 따라 토큰 요청 및 사용자 정보 처리

2. 신규 소셜 사용자 회원가입 처리
- 이메일로 기존 회원 존재 여부 확인
- 신규 사용자 처리(findOrCreate)
- 신규 사용자 저장 시 infoCompleted = false로 초기화

3. 추가 정보 입력 API 추가
- PATCH /members/me/additional-info
- 닉네임과 생년월일 입력 시 Member 엔티티 업데이트 및 infoCompleted = true 설정

4. 폼 회원가입 시 기본적으로 infoCompleted = true 처리

5. 자동 출석 기능 연동
- 로그인 성공 시 attendanceService.attend(member) 호출
- 소셜 로그인/폼 로그인 공통으로 처리
- 로그인 필터 수정

6. 닉네임/이메일 중복 검증 추가

7. 전역 예외 처리 확장
- OAuth2AuthenticationException 및 관련 예외 핸들러 추가

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 파일 혹은 폴더명 수정

## PR 안내
- PR에 소셜 로그인 기능이랑 다른 기능들이 함께 포함되어 있습니다. 기능별로 다 나눌까 했는데, 최대한 빨리 끝낼려고 하나의 pr로 다 담은 점 양해 부탁드립니다! 
